### PR TITLE
Exclude YTPlayer activation from mobile devices

### DIFF
--- a/app/assets/javascripts/app/app.js
+++ b/app/assets/javascripts/app/app.js
@@ -49,7 +49,10 @@ events: {
     Backbone.history.start({pushState: false});
     this.maskAllElements();
     this.applyErrors();
-    this.player = $(".player").YTPlayer();
+    jQuery.browser.mobile = jQuery.browser.android || jQuery.browser.blackberry || jQuery.browser.ios || jQuery.browser.windowsMobile || jQuery.browser.operaMobile || jQuery.browser.kindle;
+    if (!jQuery.browser.mobile) {
+      this.player = $(".player").YTPlayer();
+    }
   },
 
   flash: function() {


### PR DESCRIPTION
"This player doesn’t work as background for devices due to the restriction policy adopted by all on managing multimedia files via javascript. "

https://github.com/pupunzi/jquery.mb.YTPlayer/wiki